### PR TITLE
:bug Remove instructor

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+2.0.2
+=====
+* Remove user from course - remove from both the student group and faculty group
+
 2.0.1
 =====
 * remove Mediathread only logged-in.js injector view

--- a/courseaffils/forms.py
+++ b/courseaffils/forms.py
@@ -87,9 +87,12 @@ class CourseAdminForm(forms.ModelForm):
         users = self.cleaned_data['users_to_remove']
         if self.instance.group_id:
             group = self.instance.group
+            fgroup = self.instance.faculty_group
 
             for user in users:
                 user.groups.remove(group)
+                user.groups.remove(fgroup)
+                
         return users
 
     def _clean_add_user(self):

--- a/courseaffils/tests/test_forms.py
+++ b/courseaffils/tests/test_forms.py
@@ -8,11 +8,16 @@ class FormsSimpleTest(TestCase):
     def setUp(self):
         self.student_group = Group.objects.create(name="studentgroup")
         self.faculty_group = Group.objects.create(name="facultygroup")
+
         self.student = User.objects.create(username="student",
                                            last_name="long enough")
-        self.faculty = User.objects.create(username="faculty")
         self.student.groups.add(self.student_group)
+        
+        # faculty are part of both student & faculty groups
+        self.faculty = User.objects.create(username="faculty")
+        self.faculty.groups.add(self.student_group)
         self.faculty.groups.add(self.faculty_group)
+        
         self.c = Course.objects.create(
             group=self.student_group,
             title="test course",
@@ -28,8 +33,34 @@ class FormsSimpleTest(TestCase):
             dict(title="foo",
                  group=s2.id,
                  faculty_group=self.faculty_group.id,
-                 add_user='student\n*nonexistant:foo',
+                 add_user='student\n*nonexistant:foo'
                  ))
         f.save(commit=False)
         f.clean()
         f.clean_users_to_remove()
+        
+        self.assertTrue(s2 in self.student.groups.all())
+        self.assertFalse(self.faculty_group in self.student.groups.all())
+        
+        user = User.objects.filter(username='nonexistant').first()
+        self.assertIsNotNone(user)
+        self.assertTrue(s2 in user.groups.all())
+        self.assertTrue(self.faculty_group in user.groups.all())
+        
+    def test_clean_remove(self):
+        f = CourseAdminForm(instance=self.c)
+        f.cleaned_data = dict(pk=self.c.id,
+                              title="test course",
+                              group=self.student_group.id,
+                              faculty_group=self.faculty_group.id,
+                              add_user='',
+                              users_to_remove=[self.faculty, self.student]
+                              )
+        f.save(commit=False)
+        f.clean()
+        f.clean_users_to_remove()
+        
+        self.assertFalse(self.student_group in self.student.groups.all())
+        
+        self.assertFalse(self.student_group in self.faculty.groups.all())
+        self.assertFalse(self.faculty_group in self.faculty.groups.all())

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.0.1'
+version = '2.0.2'
 
 
 setup(name='django-courseaffils',


### PR DESCRIPTION
Removing an instructor from a course previously only removed them from the course's student group. Readding the user to the course automtically made them an instructor. The code now pulls an instructor from both the student and faculty groups.
Fixes PMT#101354