### PR TITLE
SW course sections can now start with letters, not only digits

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+2.0.4
+=====
+* Fix deprecated reference to form.util.
+* Accept alphanumeric section keys
+
 2.0.3
 =====
 * Minor optimizations

--- a/courseaffils/columbia.py
+++ b/courseaffils/columbia.py
@@ -160,7 +160,7 @@ class SectionkeyTemplate:
     def to_dict(sectionkey):
         key_match = re.match(
             ('(?P<year>\d{4})(?P<term>\d)(?P<dept>[\w&]{4})'
-             '(?P<number>\w{4})(?P<letter>\w)(?P<section>\d{3})'),
+             '(?P<number>\w{4})(?P<letter>\w)(?P<section>\w{3})'),
             sectionkey)
         if key_match:
             return key_match.groupdict()

--- a/courseaffils/columbia.py
+++ b/courseaffils/columbia.py
@@ -145,7 +145,7 @@ class WindTemplate:
     @staticmethod
     def to_dict(wind_string):
         wind_match = re.match(
-            ('t(?P<term>\d).y(?P<year>\d{4}).s(?P<section>\d{3})'
+            ('t(?P<term>\d).y(?P<year>\d{4}).s(?P<section>\w{3})'
              '.c(?P<letter>\w)(?P<number>\w{4})'
              '.(?P<dept>[\w&]{4}).(?P<member>\w\w).course:columbia.edu'),
             wind_string)

--- a/courseaffils/forms.py
+++ b/courseaffils/forms.py
@@ -63,11 +63,11 @@ class CourseAdminForm(forms.ModelForm):
             if hasattr(settings, 'COURSEAFFILS_COURSESTRING_MAPPER'):
                 msg = msg + ' or enter a course string'
                 if not 'course_string' not in self._errors:
-                    self._errors['course_string'] = forms.util.ErrorList()
+                    self._errors['course_string'] = forms.utils.ErrorList()
                 self._errors['course_string'].append(msg)
                 if 'course_string' in self.cleaned_data:
                     del self.cleaned_data["course_string"]
-            self._errors['group'] = forms.util.ErrorList([msg])
+            self._errors['group'] = forms.utils.ErrorList([msg])
             if 'group' in self.cleaned_data:
                 self.cleaned_data["group"]
             raise forms.ValidationError(msg)
@@ -75,7 +75,7 @@ class CourseAdminForm(forms.ModelForm):
         if Course.objects.filter(
                 group=self.cleaned_data['group']).exclude(pk=self.instance.pk):
             msg = "The group you selected is already associated with a course."
-            self._errors['group'] = forms.util.ErrorList([msg])
+            self._errors['group'] = forms.utils.ErrorList([msg])
             raise forms.ValidationError(msg)
 
         # run here, so the cleaned group from above can be used

--- a/courseaffils/tests/test_columbia.py
+++ b/courseaffils/tests/test_columbia.py
@@ -83,6 +83,12 @@ class ColumbiaSimpleTest(TestCase):
             WindTemplate.to_string(WindTemplate.to_dict(example)),
             example)
 
+        example = 't3.y2007.sd21.cw3956.engl.fc.course:columbia.edu'
+        # round-trip it
+        self.assertEquals(
+            WindTemplate.to_string(WindTemplate.to_dict(example)),
+            example)
+
     def test_csmapper_course_slug(self):
         class StubGroup(object):
             name = 't3.y2007.s001.cw3956.engl.fc.course:columbia.edu'

--- a/courseaffils/tests/test_columbia.py
+++ b/courseaffils/tests/test_columbia.py
@@ -53,9 +53,9 @@ class ColumbiaSimpleTest(TestCase):
         pass
 
     def test_sectionkeytemplate(self):
-        example = '20101SCNC1000F001'  # and 20103MIMD036PN004
+        example1 = '20101SCNC1000F001'  # and 20103MIMD036PN004
         self.assertEquals(
-            SectionkeyTemplate.to_dict(example),
+            SectionkeyTemplate.to_dict(example1),
             dict(
                 year="2010",
                 term="1",
@@ -63,6 +63,18 @@ class ColumbiaSimpleTest(TestCase):
                 number="1000",
                 letter="F",
                 section="001",))
+
+        # a newstyle sw section key, w/ a leading letter for the section                                                       
+        example2 = '20153SOCW0006TD21'
+        self.assertEquals(
+            SectionkeyTemplate.to_dict(example2),
+            dict(
+                year="2015",
+                term="3",
+                dept="SOCW",
+                number="0006",
+                letter="T",
+                section="D21",))
 
     def test_windtemplate(self):
         example = 't3.y2007.s001.cw3956.engl.fc.course:columbia.edu'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.0.2'
+version = '2.0.3'
 
 
 setup(name='django-courseaffils',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.0.3'
+version = '2.0.4'
 
 
 setup(name='django-courseaffils',


### PR DESCRIPTION
SW reported problems adding sections keys with leading letters (not digits) to care-ssw (aka carr).  I think this will likely affect our other apps too. Would be nice if we could learn about such changes in rules, but cest la vie. 

I added a test and changed the regex here, though after someone looks at this it probably needs to be redeployed to at least carr and medithread. Not sure what else. 

