### PR TITLE
Remove extraneous search criteria from admin course list view.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+2.0.6
+=====
+Remove extraneous search criteria from admin course list view. The
+extra (and never used or displayed) search fields results in duplicates.
+
 2.0.5
 =====
 Django 1.8 compatability

--- a/courseaffils/admin.py
+++ b/courseaffils/admin.py
@@ -7,8 +7,7 @@ from courseaffils.forms import CourseAdminForm
 class CourseAdmin(admin.ModelAdmin):
     form = CourseAdminForm
 
-    search_fields = ('title', 'group__name',
-                     'faculty_group__user__last_name')
+    search_fields = ('title',)
     list_display = ('title', 'id',)
     change_form_template = "courseaffils/admin_change_form.html"
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.0.5'
+version = '2.0.6'
 
 
 setup(name='django-courseaffils',


### PR DESCRIPTION
The extra (and never used or displayed) search fields result in object duplication.