### PR TITLE
remove deprecated --use-mirrors option from pip commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 python:
   - "2.7"
 install:
-  - pip install -r test_reqs.txt --use-mirrors
-  - pip install -q -e . --use-mirrors
+  - pip install -r test_reqs.txt
+  - pip install -q -e .
 script:
   - python runtests.py
 notifications:


### PR DESCRIPTION
https://pip.pypa.io/en/stable/news/