### PR TITLE
Provide WindTemplate.to_dict through CourseStringMapper

### DIFF
--- a/courseaffils/columbia.py
+++ b/courseaffils/columbia.py
@@ -130,6 +130,14 @@ class CourseStringMapper:
             slug = re.sub(' ', '_', course.title)
         return re.sub('\W', '', slug)
 
+    @staticmethod
+    def to_string(cdict):
+        return WindTemplate.to_string(cdict)
+
+    @staticmethod
+    def to_dict(wind_string):
+        return WindTemplate.to_dict(wind_string)
+
 
 class WindTemplate:
     example = 't3.y2007.s001.cw3956.engl.fc.course:columbia.edu'

--- a/courseaffils/tests/test_columbia.py
+++ b/courseaffils/tests/test_columbia.py
@@ -91,6 +91,9 @@ class ColumbiaSimpleTest(TestCase):
         self.assertEqual(
             WindTemplate.to_string(WindTemplate.to_dict(example)),
             example)
+        self.assertEqual(
+            CourseStringMapper.to_string(CourseStringMapper.to_dict(example)),
+            example)
 
     def test_csmapper_course_slug(self):
         class StubGroup(object):


### PR DESCRIPTION
I need to parse the affiliation string in Mediathread, and
in order to take advantage of the COURSEAFFILS_COURSESTRING_MAPPER
config setting (for installations outside columbia), this needs to be
available through the CourseStringMapper object.