### PR TITLE
Add Affil.past_present_future

### DIFF
--- a/courseaffils/lib.py
+++ b/courseaffils/lib.py
@@ -4,13 +4,7 @@ from django.contrib.auth.models import User
 from django.template.loader import get_template
 from django.template import Context
 from django.http import Http404
-from django.utils import timezone
 from courseaffils.models import Affil, Course
-
-
-SPRING = 1
-SUMMER = 2
-FALL = 3
 
 
 def faculty_courses_for_user(user):
@@ -89,23 +83,3 @@ def get_public_name(user_s, request):
 # AUTO_COURSE_SELECT[my_view] = my_view_courselookup
 #
 AUTO_COURSE_SELECT = {}
-
-
-def get_current_term():
-    """Find out what semester we're currently in.
-
-    Return values are:
-    1 - Spring
-    2 - Summer
-    3 - Fall
-    """
-    today = timezone.now().date()
-
-    # Assume that schools start summer semester in the second half
-    # of May or later.
-    if today.month <= 4 or (today.month == 5 and today.day <= 15):
-        return SPRING
-    elif today.month <= 8:
-        return SUMMER
-    else:
-        return FALL

--- a/courseaffils/tests/test_lib.py
+++ b/courseaffils/tests/test_lib.py
@@ -5,12 +5,11 @@ from django.template import TemplateDoesNotExist
 from courseaffils.lib import (
     faculty_courses_for_user,
     users_in_course, in_course,
-    in_course_or_404, get_current_term,
+    in_course_or_404,
     handle_public_name, get_public_name,
 )
 from courseaffils.models import Course
 from django.contrib.auth.models import Group, User
-from freezegun import freeze_time
 
 
 class DummyRequest(object):
@@ -73,23 +72,3 @@ class LibsSimpleTest(TestCase):
         self.assertEqual(faculty_courses.first(), self.c)
         self.assertEqual(student_courses.count(), 0)
         self.assertEqual(student_courses.first(), None)
-
-
-class TestUtils(TestCase):
-    def test_get_current_term(self):
-        with freeze_time('2016-01-01'):
-            self.assertEqual(get_current_term(), 1)
-        with freeze_time('2016-03-16'):
-            self.assertEqual(get_current_term(), 1)
-        with freeze_time('2016-04-30'):
-            self.assertEqual(get_current_term(), 1)
-        with freeze_time('2016-05-01'):
-            self.assertEqual(get_current_term(), 1)
-        with freeze_time('2016-05-20'):
-            self.assertEqual(get_current_term(), 2)
-        with freeze_time('2016-08-20'):
-            self.assertEqual(get_current_term(), 2)
-        with freeze_time('2016-09-02'):
-            self.assertEqual(get_current_term(), 3)
-        with freeze_time('2016-12-12'):
-            self.assertEqual(get_current_term(), 3)

--- a/courseaffils/tests/test_models.py
+++ b/courseaffils/tests/test_models.py
@@ -9,6 +9,7 @@ from courseaffils.tests.factories import (
     AffilFactory, CourseFactory, UserFactory
 )
 from django.contrib.auth.models import Group, User
+from freezegun import freeze_time
 
 
 class UserTests(TestCase):
@@ -190,6 +191,55 @@ class AffilTest(TestCase):
 
     def test_str(self):
         self.assertEqual(smart_text(self.aa), self.aa.name)
+
+    def test_past_present_future(self):
+        with freeze_time('2012-01-14'):
+            self.assertEqual(self.aa.past_present_future, 1)
+        with freeze_time('2015-01-14'):
+            self.assertEqual(self.aa.past_present_future, 1)
+        with freeze_time('2015-08-15'):
+            self.assertEqual(self.aa.past_present_future, 1)
+        with freeze_time('2015-12-15'):
+            self.assertEqual(self.aa.past_present_future, 1)
+        with freeze_time('2016-01-14'):
+            self.assertEqual(self.aa.past_present_future, 0)
+        with freeze_time('2016-04-26'):
+            self.assertEqual(self.aa.past_present_future, 0)
+        with freeze_time('2016-06-04'):
+            self.assertEqual(self.aa.past_present_future, -1)
+        with freeze_time('2017-01-14'):
+            self.assertEqual(self.aa.past_present_future, -1)
+        with freeze_time('2017-03-30'):
+            self.assertEqual(self.aa.past_present_future, -1)
+        with freeze_time('2017-10-03'):
+            self.assertEqual(self.aa.past_present_future, -1)
+        with freeze_time('2017-12-03'):
+            self.assertEqual(self.aa.past_present_future, -1)
+
+        aa = AffilFactory(
+            name='t2.y2016.s001.cf1002.scnc.st.course:columbia.edu')
+        with freeze_time('2016-01-14'):
+            self.assertEqual(aa.past_present_future, 1)
+        with freeze_time('2016-04-26'):
+            self.assertEqual(aa.past_present_future, 1)
+        with freeze_time('2016-08-12'):
+            self.assertEqual(aa.past_present_future, 0)
+        with freeze_time('2017-12-03'):
+            self.assertEqual(aa.past_present_future, -1)
+
+        aa = AffilFactory(
+            name='t3.y2016.s001.cf1002.scnc.st.course:columbia.edu')
+        with freeze_time('2016-01-14'):
+            self.assertEqual(aa.past_present_future, 1)
+        with freeze_time('2016-04-26'):
+            self.assertEqual(aa.past_present_future, 1)
+        with freeze_time('2016-10-02'):
+            self.assertEqual(aa.past_present_future, 0)
+        with freeze_time('2017-12-03'):
+            self.assertEqual(aa.past_present_future, -1)
+
+        aa = AffilFactory(name='bogus affil string')
+        self.assertEqual(aa.past_present_future, None)
 
     def test_courseworks_name(self):
         self.assertEqual(

--- a/courseaffils/tests/test_utils.py
+++ b/courseaffils/tests/test_utils.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from courseaffils.utils import get_current_term
+from freezegun import freeze_time
+
+
+class TestUtils(TestCase):
+    def test_get_current_term(self):
+        with freeze_time('2016-01-01'):
+            self.assertEqual(get_current_term(), 1)
+        with freeze_time('2016-03-16'):
+            self.assertEqual(get_current_term(), 1)
+        with freeze_time('2016-04-30'):
+            self.assertEqual(get_current_term(), 1)
+        with freeze_time('2016-05-01'):
+            self.assertEqual(get_current_term(), 1)
+        with freeze_time('2016-05-20'):
+            self.assertEqual(get_current_term(), 2)
+        with freeze_time('2016-08-20'):
+            self.assertEqual(get_current_term(), 2)
+        with freeze_time('2016-09-02'):
+            self.assertEqual(get_current_term(), 3)
+        with freeze_time('2016-12-12'):
+            self.assertEqual(get_current_term(), 3)

--- a/courseaffils/utils.py
+++ b/courseaffils/utils.py
@@ -1,0 +1,26 @@
+from django.utils import timezone
+
+
+SPRING = 1
+SUMMER = 2
+FALL = 3
+
+
+def get_current_term():
+    """Find out what semester we're currently in.
+
+    Return values are:
+    1 - Spring
+    2 - Summer
+    3 - Fall
+    """
+    today = timezone.now().date()
+
+    # Assume that schools start summer semester in the second half
+    # of May or later.
+    if today.month <= 4 or (today.month == 5 and today.day <= 15):
+        return SPRING
+    elif today.month <= 8:
+        return SUMMER
+    else:
+        return FALL

--- a/courseaffils/views.py
+++ b/courseaffils/views.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 import json
-from courseaffils.lib import get_current_term
+from courseaffils.utils import get_current_term
 from courseaffils.forms import CourseCreateForm
 from courseaffils.models import Course, CourseAccess
 from django.db.models import Q


### PR DESCRIPTION
For determining whether an affil belongs in Mediathread's past, present
or future courses table.

It's named kind of weird.. I'm open to suggestions.