### PR TITLE
Add missing python_2_unicode_compatible decorator

### DIFF
--- a/courseaffils/models.py
+++ b/courseaffils/models.py
@@ -133,6 +133,7 @@ class CourseSettings(models.Model):
         verbose_name_plural = 'Course Settings'
 
 
+@python_2_unicode_compatible
 class CourseInfo(models.Model):
     term_choices = {1: 'Spring', 2: 'Summer', 3: 'Fall'}
 


### PR DESCRIPTION
CourseInfo has a `__str__` method that needs to be `__unicode__` on
python 2.