### PR TITLE
Add sandbox courses filter - PMT #107323

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+2.1.9
+====================
+* Allow Sandbox courses to be queried for in CourseListView.
+
 2.1.8 (2016-05-20)
 ====================
 * Added Affil admin control

--- a/courseaffils/templates/courseaffils/course_list.html
+++ b/courseaffils/templates/courseaffils/course_list.html
@@ -27,6 +27,9 @@
                            href="?semester_view=future"
                            class="btn btn-default {% if semester_view == 'future' %}active{% endif %}"
                         >Future Semesters</a>
+                        <a href="?semester_view=future"
+                           class="btn btn-default {% if semester_view == 'sandbox' %}active{% endif %}"
+                        >Sandboxes</a>
                     </div>
                 </div>
 
@@ -58,29 +61,6 @@
                         {% endfor %}
                     </tbody>
                 </table>
-
-                {% if infoless_courses %}
-                    <h1>Sandboxes</h1>
-                    <table class="table course-choices tablesorter">
-                        <thead>
-                            <tr>
-                                <th>Course Titles</th>
-                                <th>Term</th>
-                                <th>Instructor</th>
-                                <th>Role</th>
-                                {% if add_privilege %}
-                                    <th class="nosort">Actions</th>
-                                {% endif %}
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for course in infoless_courses %}
-                                {% include 'courseaffils/course_row.html' %}
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                {% endif %}
-
             {% endwith %}
         {% endwith %}
     </div>

--- a/courseaffils/tests/test_views.py
+++ b/courseaffils/tests/test_views.py
@@ -21,7 +21,6 @@ class CourseListViewTests(TestCase):
         response = self.client.get(reverse('select_course'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['object_list']), 0)
-        self.assertEqual(len(response.context['infoless_courses']), 0)
 
     def test_select_course(self):
         u = UserFactory(username='test')
@@ -32,8 +31,11 @@ class CourseListViewTests(TestCase):
         response = self.client.get(reverse('select_course'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['object_list']), 0)
+        response = self.client.get(reverse('select_course'),
+                                   {'semester_view': 'sandbox'})
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            len(response.context['infoless_courses']), 0,
+            len(response.context['object_list']), 0,
             'Non-staff users shouldn\'t see sandbox courses '
             'they aren\'t part of.')
 
@@ -41,12 +43,14 @@ class CourseListViewTests(TestCase):
         response = self.client.get(reverse('select_course'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['object_list']), 0)
+        response = self.client.get(reverse('select_course'),
+                                   {'semester_view': 'sandbox'})
         self.assertEqual(
-            len(response.context['infoless_courses']), 1,
+            len(response.context['object_list']), 1,
             'Non-staff users should see sandbox courses '
             'they are grouped with.')
         self.assertEqual(
-            response.context['infoless_courses'][0].title,
+            response.context['object_list'][0].title,
             'My Course')
 
     def test_select_course_staff(self):
@@ -58,9 +62,11 @@ class CourseListViewTests(TestCase):
         response = self.client.get(reverse('select_course'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['object_list']), 0)
-        self.assertEqual(len(response.context['infoless_courses']), 1)
+        response = self.client.get(reverse('select_course'),
+                                   {'semester_view': 'sandbox'})
+        self.assertEqual(len(response.context['object_list']), 1)
         self.assertEqual(
-            response.context['infoless_courses'][0].title,
+            response.context['object_list'][0].title,
             'My Course')
 
 


### PR DESCRIPTION
This removes the `infoless_courses` context variable. Sandbox courses
are no longer queried in each CourseListView request.