### PR TITLE
Fix error in CourseAdminForm.clean()

### DIFF
--- a/courseaffils/forms.py
+++ b/courseaffils/forms.py
@@ -64,7 +64,7 @@ class CourseAdminForm(forms.ModelForm):
             msg = 'You must select a group'
             if hasattr(settings, 'COURSEAFFILS_COURSESTRING_MAPPER'):
                 msg = msg + ' or enter a course string'
-                if not 'course_string' not in self._errors:
+                if 'course_string' not in self._errors:
                     self._errors['course_string'] = forms.utils.ErrorList()
                 self._errors['course_string'].append(msg)
                 if 'course_string' in self.cleaned_data:


### PR DESCRIPTION
Addresses Sentry error:
https://sentry.ccnmtl.columbia.edu/sentry-internal/mediathread/group/922/

It looks like this boolean was flipped... maybe there was some confusion
because of the double negative:

	if not 'course_string' not in self._errors:

I think what this piece of code is intending to do is initialize
`self._errors['course_string']` if it doesn't exist.

I added a test to go through this code path.