### PR TITLE
set_course: verify requested course is valid

### DIFF
--- a/courseaffils/middleware.py
+++ b/courseaffils/middleware.py
@@ -9,6 +9,7 @@ from courseaffils.views import CourseListView
 from courseaffils.lib import AUTO_COURSE_SELECT, is_faculty
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import resolve, Resolver404
+from django.shortcuts import get_object_or_404
 
 STRUCTURED_COLLABORATION_AVAILABLE = False
 try:
@@ -127,7 +128,7 @@ class CourseManagerMiddleware(object):
             del request.session[SESSION_KEY]
 
         if 'set_course' in request.REQUEST:
-            course = Course.objects.get(
+            course = get_object_or_404(Course,
                 group__name=request.REQUEST['set_course'])
             if request.user.is_staff or \
                CourseAccess.allowed(request) or \

--- a/courseaffils/middleware.py
+++ b/courseaffils/middleware.py
@@ -128,7 +128,8 @@ class CourseManagerMiddleware(object):
             del request.session[SESSION_KEY]
 
         if 'set_course' in request.REQUEST:
-            course = get_object_or_404(Course,
+            course = get_object_or_404(
+                Course,
                 group__name=request.REQUEST['set_course'])
             if request.user.is_staff or \
                CourseAccess.allowed(request) or \

--- a/courseaffils/tests/test_middleware.py
+++ b/courseaffils/tests/test_middleware.py
@@ -104,7 +104,7 @@ class MiddlewareSimpleTest(TestCase):
         r.user = self.student
         r.REQUEST['set_course'] = 'foobarbaz'
         with self.assertRaises(Http404):
-            response = c.process_request(r) 
+            c.process_request(r)
 
         r = StubRequest(self.c)
         r.user = self.student

--- a/courseaffils/tests/test_middleware.py
+++ b/courseaffils/tests/test_middleware.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
 
-from django.test import TestCase
-from courseaffils.middleware import is_anonymous_path
-from courseaffils.middleware import already_selected_course
 from courseaffils.middleware import CourseManagerMiddleware
-from django.contrib.auth.models import Group, User
+from courseaffils.middleware import already_selected_course
+from courseaffils.middleware import is_anonymous_path
 from courseaffils.models import Course
+from django.contrib.auth.models import Group, User
+from django.http.response import Http404
+from django.test import TestCase
 
 
 class StubRequest(object):
@@ -98,6 +99,12 @@ class MiddlewareSimpleTest(TestCase):
         r.user = self.student
         r.REQUEST['set_course'] = 'studentgroup'
         assert c.process_request(r) is None
+
+        r = StubRequest(self.c)
+        r.user = self.student
+        r.REQUEST['set_course'] = 'foobarbaz'
+        with self.assertRaises(Http404):
+            response = c.process_request(r) 
 
         r = StubRequest(self.c)
         r.user = self.student


### PR DESCRIPTION
On a set_course request, raise a 404 if the set_course parameter's value is not a valid group name. Resolves sentry #174722322