### PR TITLE
replace request.REQUEST with POST and GET

### DIFF
--- a/courseaffils/middleware.py
+++ b/courseaffils/middleware.py
@@ -127,10 +127,12 @@ class CourseManagerMiddleware(object):
         if 'unset_course' in request.GET and SESSION_KEY in request.session:
             del request.session[SESSION_KEY]
 
-        if 'set_course' in request.REQUEST:
+        set_course = request.POST.get('set_course',
+                                      request.GET.get('set_course', None))
+        if set_course is not None:
             course = get_object_or_404(
                 Course,
-                group__name=request.REQUEST['set_course'])
+                group__name=set_course)
             if request.user.is_staff or \
                CourseAccess.allowed(request) or \
                (request.user in course.members):

--- a/courseaffils/models.py
+++ b/courseaffils/models.py
@@ -200,7 +200,8 @@ class CourseDetails(models.Model):
 class CourseAccess:
     @classmethod
     def allowed(cls, request):
-        return (request.REQUEST.get('secret', None)
+        secret = request.POST.get('secret', request.GET.get('secret', None))
+        return (secret
                 in getattr(settings, 'SERVER_ADMIN_SECRETKEYS', {}).values()
                 )
 

--- a/courseaffils/tests/test_middleware.py
+++ b/courseaffils/tests/test_middleware.py
@@ -12,7 +12,7 @@ from django.test import TestCase
 class StubRequest(object):
     COOKIES = dict()
     GET = dict()
-    REQUEST = dict()
+    POST = dict()
     environ = dict()
 
     def __init__(self, c):
@@ -97,17 +97,17 @@ class MiddlewareSimpleTest(TestCase):
 
         r = StubRequest(self.c)
         r.user = self.student
-        r.REQUEST['set_course'] = 'studentgroup'
+        r.POST['set_course'] = 'studentgroup'
         assert c.process_request(r) is None
 
         r = StubRequest(self.c)
         r.user = self.student
-        r.REQUEST['set_course'] = 'foobarbaz'
+        r.POST['set_course'] = 'foobarbaz'
         with self.assertRaises(Http404):
             c.process_request(r)
 
         r = StubRequest(self.c)
         r.user = self.student
-        r.REQUEST['set_course'] = 'studentgroup'
+        r.POST['set_course'] = 'studentgroup'
         r.GET['next'] = "/foo"
         assert c.process_request(r) is not None

--- a/courseaffils/tests/test_models.py
+++ b/courseaffils/tests/test_models.py
@@ -175,7 +175,8 @@ class ModelsSimpleTest(TestCase):
         CourseAccess.respond("foo")
 
         class StubRequest(object):
-            REQUEST = dict()
+            POST = dict()
+            GET = dict()
 
         self.assertFalse(CourseAccess.allowed(StubRequest()))
 

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -7,4 +7,3 @@ pyflakes==1.2.3
 django-markwhat==1.5
 factory_boy==2.8.1
 freezegun==0.3.7
-ipdb==0.10.0


### PR DESCRIPTION
`request.REQUEST` was deprecated in 1.7 and removed in 1.9:

https://docs.djangoproject.com/en/1.8/ref/request-response/#django.http.HttpRequest.REQUEST

it used to just search `POST` first followed by `GET`, so just inline
that as the replacement.