### PR TITLE
setup PyPI deployment from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,28 @@
 language: python
 sudo: false
 python:
-  - "2.7"
-  - "3.5"
+- '2.7'
+- '3.5'
 env:
-  - DJANGO="Django>=1.8.0,<1.9.0"
-  - DJANGO="Django>=1.9.0,<1.10.0"
-  - DJANGO="Django>=1.10,<1.11.0"
-  - DJANGO="Django>=1.11,<1.12.0"
+- DJANGO="Django>=1.8.0,<1.9.0"
+- DJANGO="Django>=1.9.0,<1.10.0"
+- DJANGO="Django>=1.10,<1.11.0"
+- DJANGO="Django>=1.11,<1.12.0"
 install:
-  - pip install -q $DJANGO
-  - pip install -r test_reqs.txt
-  - pip install -q -e .
+- pip install -q $DJANGO
+- pip install -r test_reqs.txt
+- pip install -q -e .
 script:
-  - flake8 courseaffils runtests.py --max-complexity=12
-  - python runtests.py
+- flake8 courseaffils runtests.py --max-complexity=12
+- python runtests.py
 notifications:
   slack: ccnmtl:GizSNscLWJLldjQrffB8mwgm
+deploy:
+  provider: pypi
+  user: ctlpypi
+  password:
+    secure: Z41N0hpU0ouHT5CIA6ksao9NlR48PUFpPOjgVGNcXKBhgOAuM6ec/Zsnu/pGmHqs207pdQXYTbNcTLCoqW0kJ423yAbN8pqWNcPEL95U3d6Sie1wIJZAJ8YZ38lcFxrWEP6I6mAn5G1ghsxacHASu9fbdtqCzUWqyRUCXO2Ro9I=
+  on:
+    tags: true
+    distributions: sdist bdist_wheel
+    repo: ccnmtl/django_courseaffils


### PR DESCRIPTION
per instructions in the wiki here:

https://wiki.ctl.columbia.edu/index.php/PyPI_Release

this should allow TravisCI to build the sdist/wheel and upload them to
PyPI without any of us having to directly login and do it.