### PR TITLE
Django 1.11.1 supporting changes

### DIFF
--- a/courseaffils/lib.py
+++ b/courseaffils/lib.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from django.contrib.auth.models import User
 from django.template.loader import get_template
-from django.template import Context
 from django.http import Http404
 from courseaffils.models import Affil, Course
 
@@ -40,11 +39,10 @@ def in_course_or_404(username, group_or_course):
         return group.user_set.get(username=username)
     except User.DoesNotExist:
         template = get_template('not_in_course.html')
-        context = Context(
-            {
-                'user': username,
-                'course': group,
-            })
+        context = {
+            'user': username,
+            'course': group,
+        }
         response_body = template.render(context)
         raise Http404(response_body)
 

--- a/courseaffils/middleware.py
+++ b/courseaffils/middleware.py
@@ -110,9 +110,14 @@ class CourseManagerMiddleware(object):
 
     def course_list_view(self, request, override_view=None):
         if override_view is not None:
-            return override_view.as_view()(request)
+            response = override_view.as_view()(request)
+        else:
+            response = CourseListView.as_view()(request)
 
-        return CourseListView.as_view()(request)
+        if response.status_code == 200:
+            response.render()
+
+        return response
 
     def process_request(self, request, override_view=None):
         request.course = None  # must be present to be a caching key


### PR DESCRIPTION
* Replace Contexts with dicts

* The pattern of rendering a TemplateView within the middleware response breaks
in Django 1.11.1. The error is "ContentNotRenderedError.
The response content must be rendered before it can be accessed." Some
discussion of the issue is here: https://goo.gl/xrtyA4. The resolution is to
explicitly call "render" on a successful response before return.