### PR TITLE
middleware.py: inherit MiddlewareMixin

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,8 @@
 ====================
 * Add django 2.2 support, remove django 1.8
 * Fix some flake8 regex issues
+* courseaffils middleware: support MIDDLEWARE as well as MIDDLEWARE_CLASSES
+  using django's MiddlewareMixin.
 
 2.1.15 (09/11/2017)
 ====================

--- a/courseaffils/middleware.py
+++ b/courseaffils/middleware.py
@@ -8,6 +8,7 @@ from courseaffils.models import Course, CourseAccess
 from courseaffils.views import CourseListView
 from courseaffils.lib import AUTO_COURSE_SELECT, is_faculty
 from django.contrib.contenttypes.models import ContentType
+from django.utils.deprecation import MiddlewareMixin
 
 try:
     from django.urls import resolve, Resolver404
@@ -73,7 +74,7 @@ def already_selected_course(request):
     return SESSION_KEY in request.session
 
 
-class CourseManagerMiddleware(object):
+class CourseManagerMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if 'ANONYMIZE' in request.COOKIES:
             for user, uid in getattr(request, 'scrub_names', {}).items():


### PR DESCRIPTION
https://docs.djangoproject.com/en/2.2/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware

Resolves the following mediathread error with new ccnmtlsettings:

> TypeError: MethCourseManagerMiddleware() takes no arguments