### PR TITLE
Catch HTTPError exception when getting extra course info

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+2.2.1 (2019-07-24)
+====================
+* Catch the HTTPError exception in case getting extra course info
+  fails. This error was uncovered by a recent change that updated
+  the bare except statement here.
+
 2.2.0 (2019-07-19)
 ====================
 * Add django 2.2 support, remove django 1.8

--- a/courseaffils/columbia.py
+++ b/courseaffils/columbia.py
@@ -2,9 +2,10 @@ from __future__ import unicode_literals
 
 import re
 try:
+    from urllib.error import HTTPError
     from urllib.request import urlopen
 except ImportError:
-    from urllib2 import urlopen
+    from urllib2 import urlopen, HTTPError
 from time import strptime, strftime
 
 
@@ -80,6 +81,7 @@ class CourseStringMapper:
     def get_course_info(course_dict):
         directory_link = DirectoryLinkTemplate.to_string(course_dict)
         response = urlopen(directory_link).read()
+
         return DirectoryPageTemplate.to_dict(response)
 
     @staticmethod
@@ -106,7 +108,7 @@ class CourseStringMapper:
                         name=val,
                         value=info_from_web[val],
                         course=course)
-        except (TypeError, KeyError, ValueError):
+        except (TypeError, KeyError, ValueError, HTTPError):
             # oh well, couldn't get extra data.
             # maybe because it's a fake course string or not a proper course
             pass

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.2.0'
+version = '2.2.1'
 
 
 setup(name='django-courseaffils',


### PR DESCRIPTION
This error was uncovered by this change (8fbead49a7e732ce4c6dc3263231d6bb6b828255) that updated the bare except statement here.

HTTPError needs to be caught during mediathread unit testing, for urls like http://www.columbia.edu/cu/bulletin/uwb/subj/SCNC/F1000-20161-001/ that return a 404. In this case, `get_course_info()` should fail silently, returning no extra course info.