### PR TITLE
Handle AnonymousUser in handle_public_name

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+2.2.4
+====================
+* Add fix to handle_public_name() to handle anonymous users.
+
 2.2.3 (2020-03-19)
 ====================
 * Add missing migration file, to fix py3 unicode problem.

--- a/courseaffils/lib.py
+++ b/courseaffils/lib.py
@@ -52,6 +52,10 @@ ANONYMIZE_KEY = 'ccnmtl.courseaffils.anonymize'
 
 def handle_public_name(user, request):
     """guarantees no double-quotes so also json-friendly"""
+
+    if not user.is_authenticated:
+        return 'Anonymous User'
+
     if 'ANONYMIZE' in request.COOKIES:
         request.__dict__.setdefault('scrub_names', {})
         request.scrub_names[user] = user.id

--- a/courseaffils/tests/test_lib.py
+++ b/courseaffils/tests/test_lib.py
@@ -9,7 +9,7 @@ from courseaffils.lib import (
     handle_public_name, get_public_name,
 )
 from courseaffils.models import Course
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import AnonymousUser, Group, User
 
 
 class DummyRequest(object):
@@ -57,6 +57,13 @@ class LibsSimpleTest(TestCase):
         r.COOKIES['ANONYMIZE'] = True
         self.assertTrue(
             handle_public_name(self.student, r).startswith("User Name_"))
+
+        anon_user = AnonymousUser()
+        self.assertEqual(
+            handle_public_name(anon_user, r),
+            'Anonymous User',
+            'Handles anonymous users.'
+        )
 
     def test_get_public_name(self):
         r = DummyRequest()


### PR DESCRIPTION
This fixes the following error that can occur if this function is called
on an AnonymousUser:

    AttributeError: 'AnonymousUser' object has no attribute 'get_full_name'