### PR TITLE
Update README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@ django-courseaffils
 
 [![Actions Status](https://github.com/ccnmtl/django_courseaffils/workflows/build-and-test/badge.svg)](https://github.com/ccnmtl/django_courseaffils/actions)
 
-courseaffils is a django app which manages course information and can
-force course-selection after login so to make which course is selected
-part of session state.
+`django_courseaffils` is a django app which manages course information, parsing
+course info out of CAS affiliations.
 
-The selected course is available in request.course .
+The selected course is available in `request.course`.
 
 Several settings are available to be added to a django project's
 `settings.py`:


### PR DESCRIPTION
Attaching course selection to session state is actually not something we want to do going forward - we removed this functionality out of Mediathread resulting in a much simpler system. I've updated the description here to better reflect what we use this library for.