### PR TITLE
Rename WindTemplate to CourseStringTemplate

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+2.3.0
+====================
+BREAKING CHANGES:
+* Renamed columbia.WindTemplate to CourseStringTemplate
+
 2.2.7 (2022-10-24)
 ====================
 * Add better CourseDetails admin form

--- a/courseaffils/columbia.py
+++ b/courseaffils/columbia.py
@@ -64,11 +64,11 @@ class CourseStringMapper:
         from django.contrib.auth.models import Group
         section_dict = SectionkeyTemplate.to_dict(sectionkey)
         if not section_dict:
-            section_dict = WindTemplate.to_dict(sectionkey)
+            section_dict = CourseStringTemplate.to_dict(sectionkey)
 
         if section_dict:
-            stud_grp_name = WindTemplate.to_string(section_dict)
-            fac_grp_name = WindTemplate.to_string(
+            stud_grp_name = CourseStringTemplate.to_string(section_dict)
+            fac_grp_name = CourseStringTemplate.to_string(
                 dict(section_dict, member='fc'))
 
             stud_grp, created = Group.objects.get_or_create(name=stud_grp_name)
@@ -86,7 +86,7 @@ class CourseStringMapper:
 
     @staticmethod
     def on_create(course):
-        course_dict = WindTemplate.to_dict(course.group.name)
+        course_dict = CourseStringTemplate.to_dict(course.group.name)
         from courseaffils.models import CourseInfo
 
         info, created = CourseInfo.objects.get_or_create(course=course)
@@ -95,7 +95,7 @@ class CourseStringMapper:
             info.term = int(course_dict['term'])
         try:
             info_from_web = CourseStringMapper.get_course_info(
-                WindTemplate.to_dict(course.group.name))
+                CourseStringTemplate.to_dict(course.group.name))
 
             for val in info_from_web:
                 if val == 'days':
@@ -117,7 +117,7 @@ class CourseStringMapper:
     @staticmethod
     def course_slug(course, attempt=0):
         "returns a slug for the course, with higher resolution for attempt > 0"
-        class_info = WindTemplate.to_dict(course.group.name)
+        class_info = CourseStringTemplate.to_dict(course.group.name)
         slug = None
         if class_info and 'number' in class_info:
             attempts = {
@@ -134,14 +134,14 @@ class CourseStringMapper:
 
     @staticmethod
     def to_string(cdict):
-        return WindTemplate.to_string(cdict)
+        return CourseStringTemplate.to_string(cdict)
 
     @staticmethod
-    def to_dict(wind_string):
-        return WindTemplate.to_dict(wind_string)
+    def to_dict(course_string):
+        return CourseStringTemplate.to_dict(course_string)
 
 
-class WindTemplate:
+class CourseStringTemplate:
     example = 't3.y2007.s001.cw3956.engl.fc.course:columbia.edu'
 
     @staticmethod
@@ -158,14 +158,14 @@ class WindTemplate:
         )
 
     @staticmethod
-    def to_dict(wind_string):
-        wind_match = re.match(
+    def to_dict(course_string):
+        course_match = re.match(
             (r't(?P<term>\d).y(?P<year>\d{4}).s(?P<section>\w{3})'
              r'.c(?P<letter>\w)(?P<number>\w{4})'
              r'.(?P<dept>[\w&]{4}).(?P<member>\w\w).course:columbia.edu'),
-            wind_string)
-        if wind_match:
-            return wind_match.groupdict()
+            course_string)
+        if course_match:
+            return course_match.groupdict()
 
 
 class SectionkeyTemplate:

--- a/courseaffils/tests/test_columbia.py
+++ b/courseaffils/tests/test_columbia.py
@@ -5,7 +5,7 @@ from courseaffils.columbia import CourseStringMapper
 from courseaffils.columbia import DirectoryPageTemplate
 from courseaffils.columbia import HashTagTemplate, CanvasTemplate
 from courseaffils.columbia import SectionkeyTemplate
-from courseaffils.columbia import WindTemplate
+from courseaffils.columbia import CourseStringTemplate
 from django.test import TestCase
 
 
@@ -79,20 +79,23 @@ class ColumbiaSimpleTest(TestCase):
                 letter="T",
                 section="D21",))
 
-    def test_windtemplate(self):
+    def test_coursetemplate(self):
         example = 't3.y2007.s001.cw3956.engl.fc.course:columbia.edu'
         # round-trip it
         self.assertEqual(
-            WindTemplate.to_string(WindTemplate.to_dict(example)),
+            CourseStringTemplate.to_string(
+                CourseStringTemplate.to_dict(example)),
             example)
 
         example = 't3.y2007.sd21.cw3956.engl.fc.course:columbia.edu'
         # round-trip it
         self.assertEqual(
-            WindTemplate.to_string(WindTemplate.to_dict(example)),
+            CourseStringTemplate.to_string(
+                CourseStringTemplate.to_dict(example)),
             example)
         self.assertEqual(
-            CourseStringMapper.to_string(CourseStringMapper.to_dict(example)),
+            CourseStringMapper.to_string(
+                CourseStringMapper.to_dict(example)),
             example)
 
     def test_csmapper_course_slug(self):
@@ -115,7 +118,7 @@ class ColumbiaSimpleTest(TestCase):
         s, f = CourseStringMapper.get_groups('20101SCNC1000F001')
         self.assertIsNotNone(s)
         self.assertIsNotNone(f)
-        s, f = CourseStringMapper.get_groups(WindTemplate.example)
+        s, f = CourseStringMapper.get_groups(CourseStringTemplate.example)
         self.assertIsNotNone(s)
         self.assertIsNotNone(f)
 
@@ -137,9 +140,10 @@ class ColumbiaSimpleTest(TestCase):
         self.assertEquals(d['letter'], u'T')
         self.assertEquals(d['year'], u'2017')
 
-        s = WindTemplate.to_string(d)
-        self.assertEquals(s,
-                          't3.y2017.s010.ct7113.socw.st.course:columbia.edu')
+        s = CourseStringTemplate.to_string(d)
+        self.assertEquals(
+            s,
+            't3.y2017.s010.ct7113.socw.st.course:columbia.edu')
 
     def test_canvas_mapper_section_letter(self):
         d = CanvasTemplate.to_dict('SOCWT7100_D23_2018_3')
@@ -150,6 +154,7 @@ class ColumbiaSimpleTest(TestCase):
         self.assertEquals(d['letter'], u'T')
         self.assertEquals(d['year'], u'2018')
 
-        s = WindTemplate.to_string(d)
-        self.assertEquals(s,
-                          't3.y2018.sd23.ct7100.socw.st.course:columbia.edu')
+        s = CourseStringTemplate.to_string(d)
+        self.assertEquals(
+            s,
+            't3.y2018.sd23.ct7100.socw.st.course:columbia.edu')


### PR DESCRIPTION
WIND is deprecated, and the template format here isn't necessarily tied to the authentication scheme (now CAS). I think CourseStringTemplate makes more sense here.