### PR TITLE
Test on django 4.2 instead of 4.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
           python-version: ["3.8", "3.11"]
-          django-version: [3.2, 4.1]
+          django-version: [3.2, 4.2]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
4.2 is the LTS release that we'll be using for all our applications.