### PR TITLE
ValueError fix

### DIFF
--- a/courseaffils/templates/courseaffils/admin_change_form.html
+++ b/courseaffils/templates/courseaffils/admin_change_form.html
@@ -74,14 +74,15 @@
        (custom headers for style and javascript) <a href="{%url 'admin:courseaffils_coursesettings_add' %}?course={{adminform.form.instance.id}}">[Create]</a>
     {% endif %}
     </li>
-
+    {% if adminform.form.instance.id %}
     <li>Metadata (instructor, etc.): <a href="{%url 'admin:courseaffils_coursedetails_add' %}?course={{adminform.form.instance.id}}">[Add]</a>
-      <ul>
-        {% for d in adminform.form.instance.coursedetails_set.all %}
-        <li><a href="{%url 'admin:courseaffils_coursedetails_change' d.id %}">{{d.name}}: {{d.value}}</a></li>
-        {% endfor %}
-      </ul>
-    </li>
+        <ul>
+          {% for d in adminform.form.instance.coursedetails_set.all %}
+          <li><a href="{%url 'admin:courseaffils_coursedetails_change' d.id %}">{{d.name}}: {{d.value}}</a></li>
+          {% endfor %}
+        </ul>
+      </li>
+    {% endif %}
 
   </ul>
 {% endif %}


### PR DESCRIPTION
In a Django 4.2 project with Courseaffils, there is an error stemming from this line when you try to add a course from the admin panel. This would just be commenting out the code but I'm not sure if there's an easy fix or if we can just get rid of that bit.
Error:
```
ValueError at /admin/courseaffils/course/add/
'Course' instance needs to have a primary key value before this relationship can be used.
```
